### PR TITLE
missing return

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,7 +95,7 @@ server.prototype.process = function( buffer, callback, request ){
     try{
         rpcRequest = JSON.parse(buffer);
     }catch( e ){
-        callback( error(E.PARSE_ERROR) );
+        return callback( error(E.PARSE_ERROR) );
     }
 
     if( typeof rpcRequest !== 'object' || !rpcRequest.method


### PR DESCRIPTION
missing return. currently after detecting parse error, script continues to execute and delivers also invalid request error.
example from one empty get request:
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 145
Date: Thu, 24 May 2018 08:47:11 GMT
Connection: keep-alive

{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"An error occurred on the server while parsing the JSON text."},"id":null}HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 133
Date: Thu, 24 May 2018 08:47:11 GMT
Connection: keep-alive

{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"The JSON sent is not a valid request object."},"id":null}